### PR TITLE
Format scoreboard section in monospace style

### DIFF
--- a/app/cron/tasks/scorhegami_updater.py
+++ b/app/cron/tasks/scorhegami_updater.py
@@ -111,12 +111,32 @@ class ScorhegamiUpdaterTask(AsyncComponent):
             else:
                 return short_name
 
+        def _to_monospace(text: str) -> str:
+            monospace_a = ord("𝙰")
+            monospace_zero = ord("𝟶")
+
+            converted: list[str] = []
+
+            for c in text:
+                if "A" <= c <= "Z":
+                    converted.append(chr(monospace_a + ord(c) - ord("A")))
+                elif "0" <= c <= "9":
+                    converted.append(chr(monospace_zero + ord(c) - ord("0")))
+                else:
+                    converted.append(c)
+
+            return "".join(converted)
+
         rhe = game.rhe
 
         content = "FINAL\n"
-        content += "          R  H  E\n"
-        content += f"{_add_spaces(game.away_team.short_name)}  {rhe[0]:2} {rhe[1]:2} {rhe[2]:2}\n"
-        content += f"{_add_spaces(game.home_team.short_name)}  {rhe[3]:2} {rhe[4]:2} {rhe[5]:2}\n"
+        content += _to_monospace("          R  H  E\n")
+        content += _to_monospace(
+            f"{_add_spaces(game.away_team.short_name)}  {rhe[0]:2} {rhe[1]:2} {rhe[2]:2}\n"
+        )
+        content += _to_monospace(
+            f"{_add_spaces(game.home_team.short_name)}  {rhe[3]:2} {rhe[4]:2} {rhe[5]:2}\n"
+        )
 
         if game.is_scorhegami:
             content += "\nThat's ScoRHEgami!\n"


### PR DESCRIPTION
### Motivation
- Improve visual alignment of the R H E scoreboard in generated tweets by rendering the header and team score lines in a fixed-width appearance using Unicode monospace characters.
- Keep all other tweet text (e.g. `FINAL`, ScoRHEgami messaging, and historical context) using regular font so links and natural language remain unchanged.
- Preserve existing spacing/alignment behavior for two- and three-character team abbreviations and two-digit R/H/E values.

### Description
- Added a helper `_to_monospace(text: str)` in `app/cron/tasks/scorhegami_updater.py` that maps uppercase letters `A–Z` and digits `0–9` to their Unicode monospace equivalents and leaves other characters untouched.
- Applied `_to_monospace` only to the scoreboard section (`"          R  H  E\n"` and the two team lines) when building tweet `content` in `_get_tweet_content`.
- Left the rest of the tweet construction logic unchanged, including the `_add_spaces` short-name padding and ScoRHEgami/historical messaging.
- No existing behavior for counting or database writes was altered.

### Testing
- Ran `ruff check app/cron/tasks/scorhegami_updater.py` and it passed with no issues.
- No other automated test suite was executed as part of this change.

Closes #19 

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9d31e172c8322aeef8e0e65f4ae68)