### PR TITLE
Skip games with placeholder teams

### DIFF
--- a/app/cron/tasks/game_fetcher.py
+++ b/app/cron/tasks/game_fetcher.py
@@ -92,6 +92,21 @@ class GameFetcherTask(AsyncComponent):
                     await AppCtx.current.db.session.commit()
                     return
 
+                valid_games = [
+                    game
+                    for game in games
+                    if game.away_team.id != -1 and game.home_team.id != -1
+                ]
+                skipped_games = len(games) - len(valid_games)
+                if skipped_games:
+                    logger.info(
+                        "Skipped %d games with unknown teams", skipped_games
+                    )
+
+                if not valid_games:
+                    await AppCtx.current.db.session.commit()
+                    return
+
                 result = await AppCtx.current.db.session.execute(
                     pg_dialect.insert(m.Game)
                     .values(
@@ -109,9 +124,7 @@ class GameFetcherTask(AsyncComponent):
                                 "bref_url": None,
                                 "game_date": self._get_game_date(game.date),
                             }
-                            for game in games
-                            if -1 not in [game.away_team.id, game.home_team.id]
-                            # The All-Star Game shows teams having id of -1, so just skip these.
+                            for game in valid_games
                         ]
                     )
                     .on_conflict_do_nothing(index_elements=[m.Game.balldontlie_id])


### PR DESCRIPTION
## Summary

- skip fetched games whose home or away team has the balldontlie placeholder ID `-1`
- avoid issuing an empty game insert when all fetched games are skipped
- commit the fetch cursor when no valid games remain

## Root cause

The All-Star game response uses placeholder teams. The prior list-comprehension filter produced an empty values list, which SQLAlchemy rendered as `INSERT INTO game DEFAULT VALUES`. PostgreSQL then rejected the insert because `away_id` and `home_id` are required.

## Validation

- `git diff --check`
- `.venv/bin/python -m py_compile app/cron/tasks/game_fetcher.py`